### PR TITLE
clarify default upsert behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ UserTable.get({ name: "abdu" });
 _**Update**_
 
 ```js
+// if "abdu" doesn't exist, it will be added (upsert)
 UserTable.update({ name: "abdu" }, {
   friends: ["abdu", "chris"],
   points: 450,


### PR DESCRIPTION
In trying to find out how to upsert (update if primary key exists, but fall back to insert if record doesn't exist), I found that it is accomplished already by default. This change is to explain this to future users.