### PR TITLE
adds Limit parameters for queries/scans

### DIFF
--- a/lib/ConditionalQueryBuilder.js
+++ b/lib/ConditionalQueryBuilder.js
@@ -1,6 +1,6 @@
 const QueryBuilder = require('./QueryBuilder');
 
-const { RETURN_VALUES, UPDATE_TYPES } = require('./constants');
+const { RETURN_VALUES } = require('./constants');
 
 const toArray = x => (Array.isArray(x) ? x : [x]);
 
@@ -15,6 +15,11 @@ class ConditionalQueryBuilder extends QueryBuilder {
 
   useIndex(IndexName) {
     this.addParams({ IndexName });
+    return this;
+  }
+
+  limit(limit) {
+    this.options.Limit = limit;
     return this;
   }
 
@@ -148,7 +153,7 @@ class ConditionalQueryBuilder extends QueryBuilder {
     const buildedParams = Object.assign({
       TableName: this.TableName,
       ReturnValues: RETURN_VALUES[toReturn],
-    }, this.params, params);
+    }, this.params, params, this.options);
     this.params = this.buildExpressionParams();
     return buildedParams;
   }

--- a/tests/queries/query.js
+++ b/tests/queries/query.js
@@ -37,7 +37,6 @@ describe('#query', () => {
             assert.deepEqual(result.Items, [itemWithList]);
           })
       );
-
       it('returns empty array if FilterExpression does not match any item', () =>
         Table.if('age', '=', 3)
           .query('name', '=', 'query-a')
@@ -46,7 +45,6 @@ describe('#query', () => {
             assert.deepEqual(result.Items, []);
           })
       );
-
       it('returns item if attribute matches list', () =>
         Table.inList('status', [1, 2, 3])
           .query('name', '=', 'query')
@@ -55,7 +53,6 @@ describe('#query', () => {
             assert.deepEqual(result.Items, [itemWithList]);
           })
       );
-
       it('returns empty array if attribute does not match list', () =>
         Table.inList('status', [5])
           .query('name', '=', 'query')
@@ -64,6 +61,20 @@ describe('#query', () => {
             assert.deepEqual(result.Items, []);
           })
       );
+      it('returns items within limit range', async () => {
+        const newItems = [
+          ['a', 2],
+          ['b', 2],
+          ['c', 2],
+          ['d', 2]
+        ].map(([name, age]) => Table.add({ name, age }));
+        await Promise.all(newItems);
+        return Table
+          .useIndex('age-index')
+          .limit(2)
+          .query('age', '=', 2)
+          .then(({ Count }) => assert.equal(2, Count));
+      });
       it('returns only projected attributes', async () => {
         await Table.project('status')
           .query('name', '=', 'query')

--- a/tests/queries/scan.js
+++ b/tests/queries/scan.js
@@ -15,4 +15,15 @@ describe('#scan', () => {
     assert.propertyVal(t, 'Count', 1);
     assert.propertyVal(f, 'Count', 0);
   });
+
+  describe('with Limit parameter', () => {
+    [3, 2, 5, 8, 4].forEach(limit =>
+      it(`returns ${limit} items`, () =>
+        Table
+          .limit(limit)
+          .scan()
+          .then(({ Count }) => assert.equal(limit, Count))
+      )
+    );
+  });
 });


### PR DESCRIPTION
### Adds a **.limit( )** method to the queryBuilder which

##### Adds the possibility to limit query results
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Limit

##### Adds the possibility to limit scan results
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Limit